### PR TITLE
Add missing priority in the HEADER frame

### DIFF
--- a/pkg/http2/server.go
+++ b/pkg/http2/server.go
@@ -1544,6 +1544,15 @@ func (sc *serverConn) processFrame(f Frame) error {
 				headers = append(headers, metadata.HeaderField(h))
 			}
 			md.HTTP2Frames.Headers = headers
+			if f.HasPriority() {
+				md.HTTP2Frames.Priorities = append(md.HTTP2Frames.Priorities,
+					metadata.Priority{
+						StreamId:  f.StreamID,
+						StreamDep: f.Priority.StreamDep,
+						Exclusive: f.Priority.Exclusive,
+						Weight:    f.Priority.Weight,
+					})
+			}
 		}
 		return sc.processHeaders(f)
 	case *WindowUpdateFrame:


### PR DESCRIPTION
You can verify this with Chrome.

```
$ env GODEBUG=http2debug=2 go run ./example/echo-server/

http2: server read frame HEADERS flags=END_STREAM|END_HEADERS|PRIORITY stream=1 len=439
```
while the `data.HTTP2Frames.Priorities` is empty.
